### PR TITLE
Changed to correct text label id

### DIFF
--- a/examples/input/mouse_and_touch/mouse_and_touch.collection
+++ b/examples/input/mouse_and_touch/mouse_and_touch.collection
@@ -18,7 +18,7 @@ embedded_instances {
   "  }\n"
   "}\n"
   "embedded_components {\n"
-  "  id: \"Move mouse!\"\n"
+  "  id: \"label\"\n"
   "  type: \"label\"\n"
   "  data: \"size {\\n"
   "  x: 128.0\\n"


### PR DESCRIPTION
The id reffered to in the mouse_and_touch.script is `#label`, but in the collection, the ID for the text was `#Move mouse!`