### PR TITLE
Sort categories in the main menu

### DIFF
--- a/examples/_main/examples.lua
+++ b/examples/_main/examples.lua
@@ -31,6 +31,7 @@ local categories = {}
 for category,_ in pairs(examples) do
 	categories[#categories + 1] = category
 end
+table.sort(categories)
 
 for category,examples_in_category in pairs(examples) do
 	for id,example in pairs(examples_in_category) do


### PR DESCRIPTION
In this menu, the categories were always in random order - very awkward as you were looking for the menu item every time.

During development I change the bootstrap collection to my example, but before the final PR I still have to check how it works. So here you are again struggling with random order in the menu.

![image](https://github.com/user-attachments/assets/b94bd594-b6a1-4fea-a9b3-bd1f7f5b7cf9)
