### PR TITLE
Avoid delta x-y spikes in Orbit Camera example

### DIFF
--- a/examples/render/orbit_camera/orbit_camera.script
+++ b/examples/render/orbit_camera/orbit_camera.script
@@ -40,7 +40,7 @@ function update(self, dt)
 end
 
 function on_input(self, action_id, action)
-	if action_id == hash("touch") then
+	if action_id == hash("touch") and not action.pressed then
 		self.yaw   = self.yaw   - action.dx * self.rotation_speed
 		self.pitch = self.pitch + action.dy * self.rotation_speed
 	elseif action_id == hash("wheel_up") then


### PR DESCRIPTION
It turns out that on mobile devices during `action.pressed=true` the dx,dy values are very large and the camera could be rotated by a large angle on every touch. This was annoying to use.