### PR TITLE
Update Spine example to Defold 1.10.1

### DIFF
--- a/animation/spine/game.project
+++ b/animation/spine/game.project
@@ -1,7 +1,7 @@
 [project]
 title = Defold-examples
 version = 0.1
-dependencies#0 = https://github.com/defold/extension-spine/archive/refs/tags/3.6.5.zip
+dependencies#0 = https://github.com/defold/extension-spine/archive/refs/tags/3.8.2.zip
 
 [bootstrap]
 main_collection = /example/spine.collectionc


### PR DESCRIPTION
Spine example had outdated dependencies - CI failed to build https://github.com/defold/defold.github.io/actions/runs/15012351174