### PR TITLE
Convert Noise shader to version 1.4.0

### DIFF
--- a/material/noise/example/noise.fp
+++ b/material/noise/example/noise.fp
@@ -1,5 +1,13 @@
-varying mediump vec2 var_texcoord0;
-uniform lowp vec4 time;
+#version 140
+
+in mediump vec2 var_texcoord0;
+
+uniform fs_uniforms
+{
+    mediump vec4 time;
+};
+
+out mediump vec4 out_fragColor;
 
 // noise shader from https://www.shadertoy.com/view/XXBcDz
 
@@ -42,6 +50,6 @@ float fbm( vec2 p )
 void main()
 {  
     float n = fbm(var_texcoord0.xy);
-    gl_FragColor = vec4(n, n, n, 1.0);
+    out_fragColor = vec4(n, n, n, 1.0);
 }
 

--- a/material/noise/example/noise.material
+++ b/material/noise/example/noise.material
@@ -8,16 +8,8 @@ vertex_constants {
   type: CONSTANT_TYPE_WORLDVIEW
 }
 vertex_constants {
-  name: "mtx_view"
-  type: CONSTANT_TYPE_VIEW
-}
-vertex_constants {
   name: "mtx_proj"
   type: CONSTANT_TYPE_PROJECTION
-}
-vertex_constants {
-  name: "mtx_normal"
-  type: CONSTANT_TYPE_NORMAL
 }
 fragment_constants {
   name: "time"

--- a/material/noise/example/noise.vp
+++ b/material/noise/example/noise.vp
@@ -1,26 +1,23 @@
+#version 140
 
-// Positions can be world or local space, since world and normal
-// matrices are identity for world vertex space materials.
-// If world vertex space is selected, you can remove the
-// normal matrix multiplication for optimal performance.
+in highp vec4 position;
+in mediump vec2 texcoord0;
+in mediump vec3 normal;
 
-attribute highp vec4 position;
-attribute mediump vec2 texcoord0;
-attribute mediump vec3 normal;
+uniform vp_uniforms
+{
+    mediump mat4 mtx_worldview;
+    mediump mat4 mtx_proj;
+};
 
-uniform mediump mat4 mtx_worldview;
-uniform mediump mat4 mtx_view;
-uniform mediump mat4 mtx_proj;
-uniform mediump mat4 mtx_normal;
-
-varying highp vec4 var_position;
-varying mediump vec3 var_normal;
-varying mediump vec2 var_texcoord0;
+out highp vec4 var_position;
+out mediump vec2 var_texcoord0;
 
 void main()
 {
-    vec4 p = mtx_worldview * vec4(position.xyz, 1.0);
+    highp vec4 p = mtx_worldview * vec4(position.xyz, 1.0);
     var_texcoord0 = texcoord0;
+
     gl_Position = mtx_proj * p;
 }
 

--- a/material/noise/game.project
+++ b/material/noise/game.project
@@ -1,5 +1,5 @@
 [project]
-title = Defold-examples
+title = material_noise
 version = 0.1
 
 [bootstrap]


### PR DESCRIPTION
It's strange, but conversion of the shader to GLSL 1.4.0 fixed all issues.

Fixes https://github.com/defold/examples/issues/76

Requires the PR to be merged before - https://github.com/defold/defold.github.io/pull/154