### PR TITLE
Handle alignment with up direction in the Look Rotation example

### DIFF
--- a/movement/look_rotation/example/look_rotation.script
+++ b/movement/look_rotation/example/look_rotation.script
@@ -11,6 +11,11 @@ local function quat_look_rotation(forward, upwards)
 		return vmath.quat()
 	end
 
+	-- Handle alignment with up direction
+	if math.abs(vmath.dot(forward, upwards)) > 0.9999999999 then
+		return vmath.quat_from_to(vmath.vector3(0, 0, 1), forward)
+	end
+
 	-- Create a rotation matrix from the forward and upwards vectors
 	local matrix = vmath.matrix4_look_at(vmath.vector3(0), forward, upwards)
 

--- a/movement/look_rotation/example/look_rotation.script
+++ b/movement/look_rotation/example/look_rotation.script
@@ -12,7 +12,7 @@ local function quat_look_rotation(forward, upwards)
 	end
 
 	-- Handle alignment with up direction
-	if math.abs(vmath.dot(forward, upwards)) > 0.9999999999 then
+	if math.abs(vmath.dot(forward, upwards)) > 0.9999999 then
 		return vmath.quat_from_to(vmath.vector3(0, 0, 1), forward)
 	end
 


### PR DESCRIPTION
When two vectors are parallel, we cannot construct a proper orthogonal coordinate system from them. I used this code in a real game and found that this new condition is necessary to detect when the forward and upward vectors are nearly parallel.