### PR TITLE
Fix stretched example window

### DIFF
--- a/material/custom_sprite/game.project
+++ b/material/custom_sprite/game.project
@@ -11,12 +11,15 @@ shared_state = 1
 [display]
 width = 720
 height = 720
+high_dpi = 1
 
 [android]
 input_method = HiddenInputField
 
 [html5]
-scale_mode = stretch
+scale_mode = no_scale
+show_fullscreen_button = 0
+show_made_with_defold = 0
 
 [project]
 title = custom_sprite_shader


### PR DESCRIPTION
 Example is stretched causing a distorted look. 
![scscnap](https://github.com/user-attachments/assets/6d7f5e0b-99df-4b54-8ec5-07e5de4bee3e)

- Changed html5 project settings to match other examples.