### PR TITLE
186 improve examples ci workflow

### DIFF
--- a/.github/workflows/trigger-site-rebuild.yml
+++ b/.github/workflows/trigger-site-rebuild.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'skip-ci')"
     steps: [
-      { name: 'Checkout', uses: actions/checkout@v4, with: { fetch-depth: 1 } },
+      { name: 'Checkout', uses: actions/checkout@v4, with: { fetch-depth: 0 } },
       { name: 'Install Python', uses: actions/setup-python@v4, with: { python-version: 3.10.5, architecture: x64 } },
       {
         name: 'Validate examples',

--- a/.github/workflows/trigger-site-rebuild.yml
+++ b/.github/workflows/trigger-site-rebuild.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches:
       - 'master'
+    paths:
+      - '*/*/**'
+      - '.github/workflows/validate-examples.yml'
+      - '.github/workflows/trigger-site-rebuild.yml'
+      - 'validate_examples.py'
+      - 'build_examples.py'
+      - 'download_bob.py'
+      - 'create_archives.py'
 
 jobs:
   validate:
@@ -14,7 +22,7 @@ jobs:
       { name: 'Install Python', uses: actions/setup-python@v4, with: { python-version: 3.10.5, architecture: x64 } },
       {
         name: 'Validate examples',
-        run: 'python validate_examples.py'
+        run: 'python validate_examples.py --changed-from "${{ github.event.before }}" --changed-to "${{ github.sha }}"'
       }
     ]
 

--- a/.github/workflows/trigger-site-rebuild.yml
+++ b/.github/workflows/trigger-site-rebuild.yml
@@ -18,10 +18,40 @@ jobs:
       }
     ]
 
-  publish:
+  build:
     runs-on: ubuntu-latest
     needs: validate
     if: "!contains(github.event.head_commit.message, 'skip-ci')"
+    outputs:
+      example_count: ${{ steps.count.outputs.example_count }}
+    steps: [
+      { name: 'Checkout', uses: actions/checkout@v4, with: { fetch-depth: 0 } },
+      { name: 'Install Python', uses: actions/setup-python@v4, with: { python-version: 3.10.5, architecture: x64 } },
+      {
+        name: 'Install Java',
+        uses: actions/setup-java@v4,
+        with: { distribution: 'temurin', java-version: '25' }
+      },
+      {
+        name: 'Download Bob',
+        run: 'python download_bob.py --channel beta --output bob.jar'
+      },
+      {
+        id: 'count',
+        name: 'Count touched examples',
+        run: 'echo "example_count=$(python build_examples.py --changed-from \"${{ github.event.before }}\" --changed-to \"${{ github.sha }}\" --dry-run)" >> "$GITHUB_OUTPUT"'
+      },
+      {
+        name: 'Build touched examples',
+        if: steps.count.outputs.example_count != '0',
+        run: 'python build_examples.py --bob-jar bob.jar --changed-from "${{ github.event.before }}" --changed-to "${{ github.sha }}"'
+      }
+    ]
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: needs.build.outputs.example_count != '0' && !contains(github.event.head_commit.message, 'skip-ci')
     steps: [
       { name: 'Checkout', uses: actions/checkout@v4, with: { fetch-depth: 1 } },
       { name: 'Install Python', uses: actions/setup-python@v4, with: { python-version: 3.10.5, architecture: x64 } },

--- a/.github/workflows/trigger-site-rebuild.yml
+++ b/.github/workflows/trigger-site-rebuild.yml
@@ -32,6 +32,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip-ci')"
     outputs:
       example_count: ${{ steps.count.outputs.example_count }}
+      changed_examples: ${{ steps.count.outputs.changed_examples }}
     steps: [
       { name: 'Checkout', uses: actions/checkout@v4, with: { fetch-depth: 0 } },
       { name: 'Install Python', uses: actions/setup-python@v4, with: { python-version: 3.10.5, architecture: x64 } },
@@ -47,7 +48,7 @@ jobs:
       {
         id: 'count',
         name: 'Count touched examples',
-        run: 'echo "example_count=$(python build_examples.py --changed-from \"${{ github.event.before }}\" --changed-to \"${{ github.sha }}\" --dry-run)" >> "$GITHUB_OUTPUT"'
+        run: 'echo "example_count=$(python build_examples.py --changed-from \"${{ github.event.before }}\" --changed-to \"${{ github.sha }}\" --dry-run)" >> "$GITHUB_OUTPUT"; echo "changed_examples=$(python build_examples.py --changed-from \"${{ github.event.before }}\" --changed-to \"${{ github.sha }}\" --list-json)" >> "$GITHUB_OUTPUT"'
       },
       {
         name: 'Build touched examples',
@@ -82,12 +83,10 @@ jobs:
       },
       {
         name: 'Repository dispatch',
-        uses: defold/repository-dispatch@1.2.1,
-        with: {
-            repo: 'defold/defold.github.io',
-            token: '${{ secrets.SERVICES_GITHUB_TOKEN }}',
-            user: 'services@defold.se',
-            action: 'examples'
-        }
+        env: {
+          DISPATCH_TOKEN: '${{ secrets.SERVICES_GITHUB_TOKEN }}',
+          CHANGED_EXAMPLES: '${{ needs.build.outputs.changed_examples }}'
+        },
+        run: 'python -c ''import json, os; print(json.dumps({"event_type":"examples","client_payload":{"examples_sha":os.environ["GITHUB_SHA"],"changed_examples":json.loads(os.environ.get("CHANGED_EXAMPLES") or "[]")}}))'' > dispatch.json && curl --fail --request POST --url https://api.github.com/repos/defold/defold.github.io/dispatches --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${DISPATCH_TOKEN}" --header "X-GitHub-Api-Version: 2022-11-28" --data @dispatch.json'
       }
     ]

--- a/.github/workflows/trigger-site-rebuild.yml
+++ b/.github/workflows/trigger-site-rebuild.yml
@@ -6,7 +6,7 @@ on:
       - 'master'
 
 jobs:
-  build:
+  validate:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'skip-ci')"
     steps: [
@@ -15,7 +15,16 @@ jobs:
       {
         name: 'Validate examples',
         run: 'python validate_examples.py'
-      },
+      }
+    ]
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: validate
+    if: "!contains(github.event.head_commit.message, 'skip-ci')"
+    steps: [
+      { name: 'Checkout', uses: actions/checkout@v4, with: { fetch-depth: 1 } },
+      { name: 'Install Python', uses: actions/setup-python@v4, with: { python-version: 3.10.5, architecture: x64 } },
       {
         name: 'Create archives',
         run: 'python create_archives.py'

--- a/.github/workflows/validate-examples.yml
+++ b/.github/workflows/validate-examples.yml
@@ -2,15 +2,35 @@ name: Validate examples
 
 on:
   pull_request:
+    paths:
+      - '*/*/**'
+      - '.github/workflows/validate-examples.yml'
+      - '.github/workflows/trigger-site-rebuild.yml'
+      - 'validate_examples.py'
+      - 'build_examples.py'
+      - 'download_bob.py'
 
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps: [
-      { name: 'Checkout', uses: actions/checkout@v4, with: { fetch-depth: 1 } },
+      { name: 'Checkout', uses: actions/checkout@v4, with: { fetch-depth: 0 } },
       { name: 'Install Python', uses: actions/setup-python@v4, with: { python-version: 3.10.5, architecture: x64 } },
       {
         name: 'Validate examples',
-        run: 'python validate_examples.py'
+        run: 'python validate_examples.py --changed-from "${{ github.event.pull_request.base.sha }}" --changed-to "${{ github.event.pull_request.head.sha }}"'
+      },
+      {
+        name: 'Install Java',
+        uses: actions/setup-java@v4,
+        with: { distribution: 'temurin', java-version: '25' }
+      },
+      {
+        name: 'Download Bob',
+        run: 'python download_bob.py --channel beta --output bob.jar'
+      },
+      {
+        name: 'Build touched examples',
+        run: 'python build_examples.py --bob-jar bob.jar --changed-from "${{ github.event.pull_request.base.sha }}" --changed-to "${{ github.event.pull_request.head.sha }}"'
       }
     ]

--- a/build_examples.py
+++ b/build_examples.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def tracked_example_projects() -> list[Path]:
+	try:
+		output = subprocess.check_output(
+			["git", "ls-files", "*/game.project"],
+			text=True,
+			stderr=subprocess.DEVNULL,
+		)
+		projects = [Path(line).parent for line in output.splitlines() if line.strip()]
+		if projects:
+			return sorted(set(projects))
+	except (FileNotFoundError, subprocess.CalledProcessError):
+		pass
+
+	return sorted(path.parent for path in Path(".").glob("*/*/game.project"))
+
+
+def touched_example_projects(base_ref: str, head_ref: str) -> list[Path]:
+	if not base_ref or base_ref == "0000000000000000000000000000000000000000":
+		return tracked_example_projects()
+
+	output = subprocess.check_output(
+		["git", "diff", "--name-only", base_ref, head_ref],
+		text=True,
+		stderr=subprocess.DEVNULL,
+	)
+	projects: set[Path] = set()
+
+	for line in output.splitlines():
+		if not line.strip():
+			continue
+
+		path = Path(line)
+		if len(path.parts) < 2:
+			continue
+
+		project_dir = Path(path.parts[0]) / path.parts[1]
+		if (project_dir / "game.project").is_file():
+			projects.add(project_dir)
+
+	return sorted(projects)
+
+
+def parse_args() -> argparse.Namespace:
+	parser = argparse.ArgumentParser()
+	parser.add_argument("--bob-jar", default="bob.jar")
+	parser.add_argument("--changed-from", default="")
+	parser.add_argument("--changed-to", default="")
+	parser.add_argument("--dry-run", action="store_true")
+	return parser.parse_args()
+
+
+def build_project(bob_jar: str, project_dir: Path) -> None:
+	print(f"Building {project_dir}")
+	subprocess.run(
+		["java", "-jar", bob_jar, "--root", str(project_dir), "distclean", "build"],
+		check=True,
+	)
+
+
+def main() -> int:
+	args = parse_args()
+
+	if args.changed_from and args.changed_to:
+		projects = touched_example_projects(args.changed_from, args.changed_to)
+	else:
+		projects = tracked_example_projects()
+
+	if args.dry_run:
+		print(len(projects))
+		return 0
+
+	for project_dir in projects:
+		build_project(args.bob_jar, project_dir)
+
+	print("Example builds passed.")
+	return 0
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/build_examples.py
+++ b/build_examples.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 import argparse
+import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
+
+
+BUILD_SERVER_URL = "https://build-stage.defold.com/"
 
 
 def tracked_example_projects() -> list[Path]:
@@ -45,8 +50,7 @@ def touched_example_projects(base_ref: str, head_ref: str) -> list[Path]:
 			if len(path.parts) < 2:
 				continue
 
-			project_dir = Path(path.parts[0]) / path.parts[1]
-			projects.add(project_dir)
+			projects.add(Path(path.parts[0]) / path.parts[1])
 
 	return sorted(projects)
 
@@ -60,12 +64,56 @@ def parse_args() -> argparse.Namespace:
 	return parser.parse_args()
 
 
+def prepare_project_copy(project_dir: Path) -> Path:
+	temp_dir = Path(tempfile.mkdtemp(prefix="defold-example-build-"))
+	project_copy = temp_dir / project_dir.name
+	shutil.copytree(project_dir, project_copy)
+
+	game_project = project_copy / "game.project"
+	lines = game_project.read_text(encoding="utf-8").splitlines()
+	updated_lines = []
+	replaced = False
+	for line in lines:
+		if line.startswith("title = "):
+			updated_lines.append("title = Defold-examples")
+			replaced = True
+		else:
+			updated_lines.append(line)
+	if not replaced:
+		updated_lines.append("title = Defold-examples")
+	game_project.write_text("\n".join(updated_lines) + "\n", encoding="utf-8")
+
+	return project_copy
+
+
 def build_project(bob_jar: str, project_dir: Path) -> None:
 	print(f"Building {project_dir}")
-	subprocess.run(
-		["java", "-jar", bob_jar, "--root", str(project_dir), "distclean", "build"],
-		check=True,
-	)
+	bob_jar_path = Path(bob_jar).resolve()
+	project_copy = prepare_project_copy(project_dir)
+	try:
+		subprocess.run(
+			[
+				"java",
+				"-jar",
+				str(bob_jar_path),
+				"--archive",
+				"--platform",
+				"wasm-web",
+				"--architectures",
+				"wasm-web",
+				"--variant",
+				"debug",
+				"--build-server",
+				BUILD_SERVER_URL,
+				"resolve",
+				"build",
+				"bundle",
+			],
+			check=True,
+			cwd=project_copy,
+		)
+	finally:
+		shutil.rmtree(project_copy.parent)
 
 
 def main() -> int:

--- a/build_examples.py
+++ b/build_examples.py
@@ -29,22 +29,23 @@ def touched_example_projects(base_ref: str, head_ref: str) -> list[Path]:
 		return tracked_example_projects()
 
 	output = subprocess.check_output(
-		["git", "diff", "--name-only", base_ref, head_ref],
+		["git", "diff", "--name-status", "--find-renames", base_ref, head_ref],
 		text=True,
 		stderr=subprocess.DEVNULL,
 	)
 	projects: set[Path] = set()
 
 	for line in output.splitlines():
-		if not line.strip():
-			continue
+		parts = line.split("\t")
+		for candidate in parts[1:]:
+			if not candidate:
+				continue
 
-		path = Path(line)
-		if len(path.parts) < 2:
-			continue
+			path = Path(candidate)
+			if len(path.parts) < 2:
+				continue
 
-		project_dir = Path(path.parts[0]) / path.parts[1]
-		if (project_dir / "game.project").is_file():
+			project_dir = Path(path.parts[0]) / path.parts[1]
 			projects.add(project_dir)
 
 	return sorted(projects)
@@ -80,7 +81,8 @@ def main() -> int:
 		return 0
 
 	for project_dir in projects:
-		build_project(args.bob_jar, project_dir)
+		if (project_dir / "game.project").is_file():
+			build_project(args.bob_jar, project_dir)
 
 	print("Example builds passed.")
 	return 0

--- a/build_examples.py
+++ b/build_examples.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import shutil
 import subprocess
 import sys
@@ -61,6 +62,7 @@ def parse_args() -> argparse.Namespace:
 	parser.add_argument("--changed-from", default="")
 	parser.add_argument("--changed-to", default="")
 	parser.add_argument("--dry-run", action="store_true")
+	parser.add_argument("--list-json", action="store_true")
 	return parser.parse_args()
 
 
@@ -126,6 +128,10 @@ def main() -> int:
 
 	if args.dry_run:
 		print(len(projects))
+		return 0
+
+	if args.list_json:
+		print(json.dumps([str(project) for project in projects]))
 		return 0
 
 	for project_dir in projects:

--- a/download_bob.py
+++ b/download_bob.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import urllib.request
+from pathlib import Path
+
+
+GITHUB_RELEASES_URL = "https://api.github.com/repos/defold/defold/releases?per_page=100"
+
+
+def parse_args() -> argparse.Namespace:
+	parser = argparse.ArgumentParser()
+	parser.add_argument("--channel", default="beta")
+	parser.add_argument("--output", default="bob.jar")
+	return parser.parse_args()
+
+
+def fetch_releases() -> list[dict[str, object]]:
+	request = urllib.request.Request(
+		GITHUB_RELEASES_URL,
+		headers={"User-Agent": "codex-defold-examples"},
+	)
+	with urllib.request.urlopen(request) as response:
+		return json.loads(response.read().decode("utf-8"))
+
+
+def find_release(releases: list[dict[str, object]], channel: str) -> dict[str, object]:
+	channel = channel.lower()
+	for release in releases:
+		name = str(release.get("name", "")).lower()
+		tag_name = str(release.get("tag_name", "")).lower()
+		if release.get("prerelease") and (channel in name or channel in tag_name):
+			return release
+
+	raise SystemExit(f"Could not find a {channel} release for defold/defold.")
+
+
+def find_bob_asset(release: dict[str, object]) -> dict[str, object]:
+	for asset in release.get("assets", []):
+		if isinstance(asset, dict) and asset.get("name") == "bob.jar":
+			return asset
+
+	raise SystemExit("Could not find bob.jar in the selected Defold release.")
+
+
+def download_asset(url: str, output: Path) -> None:
+	request = urllib.request.Request(
+		url,
+		headers={"User-Agent": "codex-defold-examples"},
+	)
+	with urllib.request.urlopen(request) as response:
+		output.write_bytes(response.read())
+
+
+def main() -> int:
+	args = parse_args()
+	release = find_release(fetch_releases(), args.channel)
+	asset = find_bob_asset(release)
+	download_asset(str(asset["browser_download_url"]), Path(args.output))
+	print(args.output)
+	return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/download_bob.py
+++ b/download_bob.py
@@ -8,7 +8,8 @@ import urllib.request
 from pathlib import Path
 
 
-GITHUB_RELEASES_URL = "https://api.github.com/repos/defold/defold/releases?per_page=100"
+INFO_URL_TEMPLATE = "https://d.defold.com/{channel}/info.json"
+BOB_URL_TEMPLATE = "https://d.defold.com/archive/{sha1}/bob/bob.jar"
 
 
 def parse_args() -> argparse.Namespace:
@@ -18,32 +19,21 @@ def parse_args() -> argparse.Namespace:
 	return parser.parse_args()
 
 
-def fetch_releases() -> list[dict[str, object]]:
+def fetch_json(url: str) -> dict[str, object]:
 	request = urllib.request.Request(
-		GITHUB_RELEASES_URL,
+		url,
 		headers={"User-Agent": "codex-defold-examples"},
 	)
 	with urllib.request.urlopen(request) as response:
 		return json.loads(response.read().decode("utf-8"))
 
 
-def find_release(releases: list[dict[str, object]], channel: str) -> dict[str, object]:
-	channel = channel.lower()
-	for release in releases:
-		name = str(release.get("name", "")).lower()
-		tag_name = str(release.get("tag_name", "")).lower()
-		if release.get("prerelease") and (channel in name or channel in tag_name):
-			return release
-
-	raise SystemExit(f"Could not find a {channel} release for defold/defold.")
-
-
-def find_bob_asset(release: dict[str, object]) -> dict[str, object]:
-	for asset in release.get("assets", []):
-		if isinstance(asset, dict) and asset.get("name") == "bob.jar":
-			return asset
-
-	raise SystemExit("Could not find bob.jar in the selected Defold release.")
+def fetch_sha1(channel: str) -> str:
+	info = fetch_json(INFO_URL_TEMPLATE.format(channel=channel))
+	sha1 = str(info.get("sha1", "")).strip()
+	if not sha1:
+		raise SystemExit(f"Could not find sha1 for Defold channel '{channel}'.")
+	return sha1
 
 
 def download_asset(url: str, output: Path) -> None:
@@ -57,9 +47,8 @@ def download_asset(url: str, output: Path) -> None:
 
 def main() -> int:
 	args = parse_args()
-	release = find_release(fetch_releases(), args.channel)
-	asset = find_bob_asset(release)
-	download_asset(str(asset["browser_download_url"]), Path(args.output))
+	sha1 = fetch_sha1(args.channel)
+	download_asset(BOB_URL_TEMPLATE.format(sha1=sha1), Path(args.output))
 	print(args.output)
 	return 0
 

--- a/validate_examples.py
+++ b/validate_examples.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import os
 import subprocess
 import sys
@@ -20,20 +21,44 @@ SCRIPT_EXTENSIONS = {
 }
 
 
-def tracked_example_docs() -> list[Path]:
+def tracked_example_dirs() -> list[Path]:
 	try:
 		output = subprocess.check_output(
-			["git", "ls-files", "*/example.md"],
+			["git", "ls-files", "*/game.project"],
 			text=True,
 			stderr=subprocess.DEVNULL,
 		)
-		files = [Path(line) for line in output.splitlines() if line.strip()]
-		if files:
-			return files
+		directories = [Path(line).parent for line in output.splitlines() if line.strip()]
+		if directories:
+			return sorted(set(directories))
 	except (FileNotFoundError, subprocess.CalledProcessError):
 		pass
 
-	return sorted(Path(".").glob("*/*/example.md"))
+	return sorted(path.parent for path in Path(".").glob("*/*/game.project"))
+
+
+def touched_example_dirs(base_ref: str, head_ref: str) -> list[Path]:
+	if not base_ref or base_ref == "0000000000000000000000000000000000000000":
+		return tracked_example_dirs()
+
+	output = subprocess.check_output(
+		["git", "diff", "--name-status", "--find-renames", base_ref, head_ref],
+		text=True,
+		stderr=subprocess.DEVNULL,
+	)
+	directories: set[Path] = set()
+
+	for line in output.splitlines():
+		parts = line.split("\t")
+		for candidate in parts[1:]:
+			if not candidate:
+				continue
+			path = Path(candidate)
+			if len(path.parts) < 2:
+				continue
+			directories.add(Path(path.parts[0]) / path.parts[1])
+
+	return sorted(directories)
 
 
 def frontmatter_value(markdown_file: Path, key: str) -> str | None:
@@ -74,11 +99,28 @@ def example_scripts(example_dir: Path) -> set[str]:
 	return scripts
 
 
+def parse_args() -> argparse.Namespace:
+	parser = argparse.ArgumentParser()
+	parser.add_argument("--changed-from", default="")
+	parser.add_argument("--changed-to", default="")
+	return parser.parse_args()
+
+
 def validate() -> int:
+	args = parse_args()
+
 	errors: list[str] = []
 
-	for markdown_file in tracked_example_docs():
-		example_dir = markdown_file.parent
+	example_dirs = (
+		touched_example_dirs(args.changed_from, args.changed_to)
+		if args.changed_from and args.changed_to
+		else tracked_example_dirs()
+	)
+
+	for example_dir in example_dirs:
+		markdown_file = example_dir / "example.md"
+		if not markdown_file.is_file():
+			continue
 		available_scripts = example_scripts(example_dir)
 
 		for script in split_scripts(frontmatter_value(markdown_file, "scripts")):


### PR DESCRIPTION
This PR changes a CI in this repo:
- On PR, `.github/workflows/validate-examples.yml` runs only if relevant paths changed.
- In that PR workflow, it validates only touched example.md files and builds only the touched example projects with Bob using the latest beta version.
- On push to master, `.github/workflows/trigger-site-rebuild.yml` again validates only touched example.md files and builds only touched example projects.

This is to ensure the following flow:
  1. On creating a PR: validate + build touched examples.
  2. On merge to master: validate + build touched examples again.
  3. Only then: trigger defold.github.io site rebuild.
  
  To make the last work we need to add this validation and build steps as required after merging, somewhere here in the Github page settings.
  
  **This should be merged after:** https://github.com/defold/defold.github.io/pull/253
  
  #186 